### PR TITLE
Implemented VismaNet as dynamic

### DIFF
--- a/ONIT.VismaNet/Dynamic/VismaNetDynamicEndpoint.cs
+++ b/ONIT.VismaNet/Dynamic/VismaNetDynamicEndpoint.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using ONIT.VismaNetApi.Lib;
+using ONIT.VismaNetApi.Models;
+
+namespace ONIT.VismaNetApi.Dynamic
+{
+    public class VismaNetDynamicEndpoint : DynamicObject
+    {
+        private readonly VismaNetAuthorization _auth;
+        private readonly string _endpointName;
+
+        internal VismaNetDynamicEndpoint(string endpointName, VismaNetAuthorization auth)
+        {
+            _endpointName = endpointName;
+            _auth = auth;
+        }
+        
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            if (binder.Name.Equals("get", StringComparison.OrdinalIgnoreCase))
+            {
+                if (args != null && args.Length > 0)
+                {
+                    result = _Get($"{args[0]}");
+                    return true;
+                }
+            }
+            if (binder.Name.Equals("all", StringComparison.OrdinalIgnoreCase))
+            {
+                result = _All(binder, args);
+                return true;
+            }
+            result = null;
+            return false;
+        }
+
+        private async Task<dynamic> _Get(string argument)
+        {
+            if (!string.IsNullOrEmpty(argument))
+            {
+                return await VismaNetApiHelper.Get<JObject>(argument, $"controller/api/v1/{_endpointName}", _auth);
+            }
+            return await Task.FromResult(default(dynamic));
+        }
+
+        private async Task<dynamic> _All(InvokeMemberBinder binder, object[] args)
+        {
+            NameValueCollection nvc = null;
+            if (binder.CallInfo.ArgumentCount > 0)
+            {
+                nvc = new NameValueCollection();
+                foreach (
+                    var keyValuePair in
+                        binder.CallInfo.ArgumentNames.Select((s, i) => new KeyValuePair<string, string>(s, $"{args[i]}"))
+                    )
+                {
+                    nvc.Add(keyValuePair.Key, keyValuePair.Value);
+                }
+            }
+            return await VismaNetApiHelper.GetAll<JObject>($"controller/api/v1/{_endpointName}", _auth, nvc);
+        }
+    }
+}

--- a/ONIT.VismaNet/Dynamic/VismaNetDynamicHandler.cs
+++ b/ONIT.VismaNet/Dynamic/VismaNetDynamicHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Dynamic;
+using ONIT.VismaNetApi.Models;
+
+namespace ONIT.VismaNetApi.Dynamic
+{
+    public abstract class VismaNetDynamicHandler : DynamicObject
+    {
+        protected VismaNetAuthorization Auth;
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            result = new VismaNetDynamicEndpoint(binder.Name, Auth);
+            return true;
+        }
+    }
+}

--- a/ONIT.VismaNet/Lib/VismaNetApiHelper.cs
+++ b/ONIT.VismaNet/Lib/VismaNetApiHelper.cs
@@ -387,7 +387,7 @@ namespace ONIT.VismaNetApi.Lib
             }
         }
 
-        internal static async Task<List<T>> GetAllModifiedSince<T>(string apiControllerUri, DateTime dateTime,
+       internal static async Task<List<T>> GetAllModifiedSince<T>(string apiControllerUri, DateTime dateTime,
             VismaNetAuthorization authorization)
         {
             using (var webclient = GetHttpClient(authorization))

--- a/ONIT.VismaNet/ONIT.VismaNet.csproj
+++ b/ONIT.VismaNet/ONIT.VismaNet.csproj
@@ -178,6 +178,8 @@
     <Compile Include="Lib\VismaNetWebClient.cs" />
     <Compile Include="Exceptions\VismaNetExceptionHandler.cs" />
     <Compile Include="Models\CompanyContext.cs" />
+    <Compile Include="Dynamic\VismaNetDynamicHandler.cs" />
+    <Compile Include="Dynamic\VismaNetDynamicEndpoint.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Tools\nuget-pack.bat" />

--- a/ONIT.VismaNet/VismaNet.cs
+++ b/ONIT.VismaNet/VismaNet.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.SqlServer.Server;
+using ONIT.VismaNetApi.Dynamic;
 using ONIT.VismaNetApi.Exceptions;
 using ONIT.VismaNetApi.Lib;
 using ONIT.VismaNetApi.Lib.Data;
@@ -12,7 +12,7 @@ using ONIT.VismaNetApi.Models;
 namespace ONIT.VismaNetApi
 {
     [ComVisible(true)]
-    public class VismaNet
+    public class VismaNet : VismaNetDynamicHandler
     {
         public readonly CashSaleData CashSales;
         public readonly CustomerDocumentData CustomerDocuments;
@@ -32,7 +32,6 @@ namespace ONIT.VismaNetApi
 
         public readonly JournalTransactionData JournalTransactions;
 
-        private readonly VismaNetAuthorization _auth;
         
         /// <summary>
         ///     Creates a connection using token.
@@ -44,27 +43,26 @@ namespace ONIT.VismaNetApi
             if (string.IsNullOrEmpty(token))
                 throw new InvalidArgumentsException("Token is missing");
 
-            _auth = new VismaNetAuthorization
+            Auth = new VismaNetAuthorization
             {
                 Token = token,
                 CompanyId = companyId
             };
-            
-            Customers = new CustomerData(_auth);
-            CustomerInvoices = new CustomerInvoiceData(_auth);
-            Suppliers = new SupplierData(_auth);
-            SupplierInvoices = new SupplierInvoiceData(_auth);
-            CashSales = new CashSaleData(_auth);
-            CustomerDocuments = new CustomerDocumentData(_auth);
-            Dimensions = new DimensionData(_auth);
-            Inventory = new InventoryData(_auth);
-            JournalTransactions = new JournalTransactionData(_auth);
-            Accounts = new FinAccountData(_auth);
-            Employee = new EmployeeData(_auth);
-            CreditNote = new CreditNoteData(_auth);
-            Shipments = new ShipmentData(_auth);
-            Contacts = new ContactData(_auth);
-            Projects = new ProjectData(_auth);
+            Customers = new CustomerData(Auth);
+            CustomerInvoices = new CustomerInvoiceData(Auth);
+            Suppliers = new SupplierData(Auth);
+            SupplierInvoices = new SupplierInvoiceData(Auth);
+            CashSales = new CashSaleData(Auth);
+            CustomerDocuments = new CustomerDocumentData(Auth);
+            Dimensions = new DimensionData(Auth);
+            Inventory = new InventoryData(Auth);
+            JournalTransactions = new JournalTransactionData(Auth);
+            Accounts = new FinAccountData(Auth);
+            Employee = new EmployeeData(Auth);
+            CreditNote = new CreditNoteData(Auth);
+            Shipments = new ShipmentData(Auth);
+            Contacts = new ContactData(Auth);
+            Projects = new ProjectData(Auth);
         }
 
         public static string Version { get; private set; }
@@ -76,7 +74,7 @@ namespace ONIT.VismaNetApi
 
         public async Task<bool> TestConnectionAsyncTask()
         {
-            return await VismaNetApiHelper.TestConnection(_auth);
+            return await VismaNetApiHelper.TestConnection(Auth);
         }
 
         public bool TestConnection()


### PR DESCRIPTION
I've implemented VismaNet as a dynamic type for reading data from the API. This means that you can access endpoints that are not explicitly implemented. All parameters passed to the function All will be passed on as parameters to the API.

```
dynamic vismaNet = new VismaNet(id, token);
foreach (var vatCode in await vismaNet.Vat.All(numberToRead: 5))
{
    Console.WriteLine($"{vatCode.vatCategoryId}: {vatCode.description}");
}
```

You'll find the name of the endpoints and the fields at https://integration.visma.net/API-index/.