### PR TITLE
Create customer and supplier without autonumbering. Closes issue #24

### DIFF
--- a/ONIT.VismaNet/Models/Customer.cs
+++ b/ONIT.VismaNet/Models/Customer.cs
@@ -12,6 +12,15 @@ namespace ONIT.VismaNetApi.Models
 		{
 			IgnoreProperties.Add (nameof(this.number));
 		}
+
+        /// <summary>
+        /// Create a new customer without autonumbering
+        /// </summary>
+        /// <param name="customerNumber"></param>
+        public Customer(string customerNumber)
+        {
+            number = customerNumber;
+        }
      
         [JsonProperty]
         public string number

--- a/ONIT.VismaNet/Models/Supplier.cs
+++ b/ONIT.VismaNet/Models/Supplier.cs
@@ -12,10 +12,20 @@ namespace ONIT.VismaNetApi.Models
 {
     public class Supplier : DtoProviderBase, IProvideIdentificator
     {
-        public Supplier() : base()
+        public Supplier()
         {
             IgnoreProperties.Add(nameof(this.number));
         }
+        /// <summary>
+        /// Create a new supplier without autonumbering
+        /// </summary>
+        /// <param name="supplierNumber"></param>
+        public Supplier(string supplierNumber)
+        {
+            number = supplierNumber;
+        }
+
+
         public int internalId
         {
             get { return Get<int>(); }


### PR DESCRIPTION
```c#
// Disable autonumbering by providing the customer number in the constructor.
var customer = new Customer("12345");
customer.name = "Test Testing";
await vismaNet.Customers.AddAsyncTask(customer);
```