### PR TITLE
Added ApplicationName to VismaNet so that Visma can see what is what

### DIFF
--- a/ONIT.VismaNet/Lib/Data/CustomerInvoiceData.cs
+++ b/ONIT.VismaNet/Lib/Data/CustomerInvoiceData.cs
@@ -71,12 +71,12 @@ namespace ONIT.VismaNetApi.Lib.Data
 
 	    public async Task<VismaActionResult> ReleaseInvoice(CustomerInvoice invoice)
 	    {
-	        return await VismaNetApiHelper.InvoiceAction(invoice.number, "release", Authorization);
+	        return await VismaNetApiHelper.InvoiceAction(invoice.GetIdentificator(), "release", Authorization);
 	    }
 
         public async Task<VismaActionResult> ReverseInvoice(CustomerInvoice invoice)
         {
-            return await VismaNetApiHelper.InvoiceAction(invoice.number, "reverse", Authorization);
+            return await VismaNetApiHelper.InvoiceAction(invoice.GetIdentificator(), "reverse", Authorization);
         }
 
 	    public async Task<string> AddAttachmentToInvoice(string invoiceNumber, string content, string fileName)

--- a/ONIT.VismaNet/Lib/VismaNetWebClient.cs
+++ b/ONIT.VismaNet/Lib/VismaNetWebClient.cs
@@ -38,8 +38,8 @@ namespace ONIT.VismaNetApi.Lib
             handler.UseCookies = false;
             httpClient = new HttpClient(handler, true);
             httpClient.Timeout = TimeSpan.FromSeconds(300);
-            httpClient.DefaultRequestHeaders.Add("User-Agent",
-                string.Format("OnItAS+VismaNet/{0}", VismaNet.Version));
+            httpClient.DefaultRequestHeaders.Add("User-Agent", $"Visma.Net/{VismaNet.Version} (+https://github.com/ON-IT/Visma.Net)");
+            httpClient.DefaultRequestHeaders.ExpectContinue = false;
         }
 
         internal VismaNetHttpClient(VismaNetAuthorization auth = null)
@@ -71,7 +71,10 @@ namespace ONIT.VismaNetApi.Lib
             message.Headers.Add("ipp-application-type", VismaNetApiHelper.ApplicationType);
             message.Headers.Accept.Clear();
             message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            message.Headers.ExpectContinue = false;
+            if (!string.IsNullOrEmpty(VismaNet.ApplicationName))
+            {
+                message.Headers.Add("User-Agent", $"Visma.Net/{VismaNet.Version} (+https://github.com/ON-IT/Visma.Net) ({VismaNet.ApplicationName})");
+            }
             return message;
         }
 

--- a/ONIT.VismaNet/VismaNet.cs
+++ b/ONIT.VismaNet/VismaNet.cs
@@ -65,7 +65,10 @@ namespace ONIT.VismaNetApi
         }
 
         public static string Version { get; private set; }
-
+        /// <summary>
+        /// Provide a name for your application. This will make it easier for Visma to identify your integration in their logs.
+        /// </summary>
+        public static string ApplicationName { get; set; }
         static VismaNet()
         {
             Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();


### PR DESCRIPTION
Please set VismaNet.ApplicationName before doing any requests. This will allow Visma to identify your application in the requests and let them contact you if anything is off on their side.

```csharp
    internal class Program
    {
        private static void Main(string[] args)
        {
            VismaNet.ApplicationName = "My Awesome Integration";
            var vismaNet = new VismaNet(12345, "1406148a-a9b5-4626-acaf-e485a85b6e0c");
            doStuff(vismaNet);

        }
   }
```