### PR TITLE
Initialize Segment with segmentId = 1

### DIFF
--- a/ONIT.VismaNet/Models/CustomDto/Segment.cs
+++ b/ONIT.VismaNet/Models/CustomDto/Segment.cs
@@ -2,7 +2,7 @@
 {
     public class Segment
     {
-        public int segmentId { get; set; }
+        public int segmentId { get; set; } = 1; // since version 6.01 this should by default 1, instead of 0
         public string segmentDescription { get; set; }
         public string segmentValue { get; set; }
         public string segmentValueDescription { get; set; }


### PR DESCRIPTION
After the 6.01 update of Visma.Net the first segment should not be 0 but 1.