### PR TITLE
Added support for /location

### DIFF
--- a/Visma.net.sln
+++ b/Visma.net.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Visma.net", "Visma.net\Visma.net.csproj", "{2486A884-F92B-4117-9A37-00F4DF67C451}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2125312D-9F7D-4581-9E51-EB6D046B5029}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Visma.net/Exceptions/VismaNetException.cs
+++ b/Visma.net/Exceptions/VismaNetException.cs
@@ -18,5 +18,7 @@ namespace ONIT.VismaNetApi.Exceptions
         }
 
         public VismaNetExceptionDetails Details { get; private set; }
+        public string Payload { get; set; }
+        public string Endpoint { get; set; }
     }
 }

--- a/Visma.net/Exceptions/VismaNetExceptionHandler.cs
+++ b/Visma.net/Exceptions/VismaNetExceptionHandler.cs
@@ -9,12 +9,12 @@ namespace ONIT.VismaNetApi
 {
     internal static class VismaNetExceptionHandler
     {
-        internal static void HandleException(AggregateException exception)
+        internal static void HandleException(AggregateException exception, string request = null, string endpoint = null)
         {
             var webException = exception.InnerException as WebException;
             if (webException == null)
                 throw exception.InnerException;
-            HandleException(webException);
+            HandleException(webException, request, endpoint);
         }
 
         internal static void HandleException(VismaNetException e)
@@ -22,7 +22,7 @@ namespace ONIT.VismaNetApi
             throw e;
         }
 
-        internal static void HandleException(WebException exception)
+        internal static void HandleException(WebException exception, string request = null, string endpoint = null)
         {
             if (exception.Response != null)
             {
@@ -30,22 +30,22 @@ namespace ONIT.VismaNetApi
                 using (var stream = response.GetResponseStream())
                 {
                     if (stream != null)
-                        HandleException(stream, exception);
+                        HandleException(stream, exception, request, endpoint);
                 }
             }
         }
 
-        internal static void HandleException(Stream stream, Exception e = null)
+        internal static void HandleException(Stream stream, Exception e = null, string request = null, string endpoint = null)
         {
-            HandleException(new StreamReader(stream).ReadToEnd(), e);
+            HandleException(new StreamReader(stream).ReadToEnd(), e, request,endpoint);
         }
 
-        internal static void HandleException(string data, Exception e = null)
+        internal static void HandleException(string data, Exception e = null, string request = null, string endpoint = null)
         {
-            ThrowException(data, e);
+            ThrowException(data, e, request);
         }
 
-        private static void ThrowException(string data, Exception ex = null)
+        private static void ThrowException(string data, Exception ex = null, string request = null, string endpoint = null)
         {
             var details = JsonConvert.DeserializeObject<VismaNetExceptionDetails>(data);
 
@@ -55,7 +55,11 @@ namespace ONIT.VismaNetApi
                     details.ExceptionMessage.IndexOf("token", StringComparison.OrdinalIgnoreCase) > -1)
                     throw new InvalidTokenException(details, ex);
             }
-            throw new VismaNetException(details, ex);
+            throw new VismaNetException(details, ex)
+            {
+                Payload = request,
+                Endpoint = endpoint
+            };
         }
     }
 }

--- a/Visma.net/Models/CustomDto/Address.cs
+++ b/Visma.net/Models/CustomDto/Address.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
-using ONIT.VismaNetApi.Annotations;
 using ONIT.VismaNetApi.Lib;
 
 namespace ONIT.VismaNetApi.Models.CustomDto
@@ -12,6 +11,7 @@ namespace ONIT.VismaNetApi.Models.CustomDto
         {
             RequiredFields.Add("county", new DtoValue(null));
         }
+
         public int addressId
         {
             get { return Get<int>(); }
@@ -20,18 +20,21 @@ namespace ONIT.VismaNetApi.Models.CustomDto
 
         public string addressLine1
         {
-            get
-            {
-                return Get<string>();
-            }
+            get { return Get<string>(); }
             set
             {
-                var split = value.Split(new[] { "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries);
-                if (split.Length>1)
+                if (string.IsNullOrEmpty(value))
+                {
+                    Set(value);
+                    return;
+                }
+
+                var split = value.Split(new[] {"\n", "\r"}, StringSplitOptions.RemoveEmptyEntries);
+                if (split.Length > 1)
                 {
                     Set(split[0]?.Trim());
                     addressLine2 = split[1];
-                    if(split.Length>2)
+                    if (split.Length > 2)
                         addressLine3 = string.Join(" ", split.Skip(2)).Trim();
                 }
                 else
@@ -74,7 +77,7 @@ namespace ONIT.VismaNetApi.Models.CustomDto
         public DescriptiveDto county
         {
             get { return Get<DescriptiveDto>(); }
-            set {  Set(value);}
+            set { Set(value); }
         }
 
         public State state
@@ -97,7 +100,7 @@ namespace ONIT.VismaNetApi.Models.CustomDto
         public override string ToString()
         {
             var builder = new StringBuilder();
-            if(!string.IsNullOrWhiteSpace(addressLine1))
+            if (!string.IsNullOrWhiteSpace(addressLine1))
                 builder.AppendLine(addressLine1);
             if (!string.IsNullOrWhiteSpace(addressLine2))
                 builder.AppendLine(addressLine2);
@@ -114,7 +117,7 @@ namespace ONIT.VismaNetApi.Models.CustomDto
                 if (!string.IsNullOrWhiteSpace(city))
                     builder.AppendLine(city);
             }
-            if(!string.IsNullOrEmpty(country?.id))
+            if (!string.IsNullOrEmpty(country?.id))
                 builder.AppendLine(country.ToString());
 
             return builder.ToString().Trim();

--- a/Visma.net/Models/CustomDto/DescriptiveDto.cs
+++ b/Visma.net/Models/CustomDto/DescriptiveDto.cs
@@ -137,6 +137,27 @@ namespace ONIT.VismaNetApi.Models
         }
     }
 
+    public class VatZone : DescriptiveDto
+    {
+        public VatZone()
+        {
+        }
+
+        public VatZone(string id)
+            : base(id)
+        {
+            
+        }
+
+        public static implicit operator VatZone(string id)
+        {
+            return new VatZone()
+            {
+                id = id
+            };
+        }
+    }
+
     public class CustomerClass : DescriptiveDto
     {
         public CustomerClass()

--- a/Visma.net/Models/Location.cs
+++ b/Visma.net/Models/Location.cs
@@ -51,9 +51,9 @@ namespace ONIT.VismaNetApi.Models
             set { Set(value); }
         }
 
-        public string vatZone
+        public VatZone vatZone
         {
-            get { return Get<string>(); }
+            get { return Get<VatZone>("vatZoneId"); }
             set { Set(value); }
         }
 

--- a/Visma.net/Models/Location.cs
+++ b/Visma.net/Models/Location.cs
@@ -1,0 +1,77 @@
+﻿using ONIT.VismaNetApi.Lib;
+using ONIT.VismaNetApi.Models.CustomDto;
+
+namespace ONIT.VismaNetApi.Models
+{
+    public class Location : DtoProviderBase, IProvideIdentificator
+    {
+        public string baccountId
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public string locationId
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public string locationName
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public bool active
+        {
+            get { return Get<bool>(); }
+            set { Set(value); }
+        }
+
+        public bool addressIsSameAsMain
+        {
+            get { return Get<bool>(); }
+            set { Set(value); }
+        }
+
+        public Address address { get { return Get<Address>(); } set { Set(value); } }
+
+        public bool contactIsSameAsMain
+        {
+            get { return Get<bool>(); }
+            set { Set(value); }
+        }
+
+        public ContactInfo contact { get { return Get<ContactInfo>(); } set { Set(value); } }
+
+        public string vatRegistrationId
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public string vatZone
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public string ediCode
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public string gln
+        {
+            get { return Get<string>(); }
+            set { Set(value); }
+        }
+
+        public string GetIdentificator()
+        {
+            return baccountId;
+        }
+    }
+}

--- a/Visma.net/Visma.net.csproj
+++ b/Visma.net/Visma.net.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<Title>Visma.net</Title>
-        <Version>3.0.0</Version>
+        <Version>3.0.1</Version>
         <Copyright>Copyright © ON IT AS 2014 - 2017</Copyright>
         <Description>Get started with Visma.net Integrations.</Description>
         <Authors>ON IT AS</Authors>
@@ -11,7 +11,7 @@
         <PackageProjectUrl>https://github.com/ON-IT/Visma.Net</PackageProjectUrl>
         <RepositoryUrl>https://github.com/ON-IT/Visma.Net.git</RepositoryUrl>
         <PackageTags>Visma.net API, Visma.net Integrations, REST</PackageTags>
-        <PackageReleaseNotes>Added support for Net Standard 2.0. The binary is renamed Visma.net, and this might break your build!</PackageReleaseNotes>
+        <PackageReleaseNotes>Fixed an issue with setting addressLine1 to null on Address.</PackageReleaseNotes>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
         <RepositoryType>git</RepositoryType>

--- a/Visma.net/Visma.net.csproj
+++ b/Visma.net/Visma.net.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<Title>Visma.net</Title>
-        <Version>3.0.1</Version>
+        <Version>3.0.2</Version>
         <Copyright>Copyright © ON IT AS 2014 - 2017</Copyright>
         <Description>Get started with Visma.net Integrations.</Description>
         <Authors>ON IT AS</Authors>

--- a/Visma.net/VismaNet.cs
+++ b/Visma.net/VismaNet.cs
@@ -123,7 +123,6 @@ namespace ONIT.VismaNetApi
 		public async Task<Stream> GetAttchment(string attachmentId)
 		{
 			return await VismaNetApiHelper.GetAttachment(Auth, attachmentId);
-
 		}
     }
 }

--- a/Visma.net/VismaNet.cs
+++ b/Visma.net/VismaNet.cs
@@ -34,6 +34,7 @@ namespace ONIT.VismaNetApi
         public readonly PaymentData Payment;
         public readonly BranchData Branch;
         public readonly WarehouseData Warehouse;
+        public readonly LocationData Location;
 
         /// <summary>
         ///     Creates a connection using token.
@@ -71,6 +72,7 @@ namespace ONIT.VismaNetApi
             Payment = new PaymentData(Auth);
             Branch = new BranchData(Auth);
             Warehouse = new WarehouseData(Auth);
+            Location = new LocationData(Auth);
         }
 
         public static string Version { get; private set; }

--- a/Visma.net/lib/DAta/LocationData.cs
+++ b/Visma.net/lib/DAta/LocationData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Threading.Tasks;
 using ONIT.VismaNetApi.Models;
 
@@ -22,14 +23,101 @@ namespace ONIT.VismaNetApi.Lib.Data
             throw new NotImplementedException();
         }
 
+        public override Task<List<Location>> Find(NameValueCollection parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task ForEach(Action<Location> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task ForEach(Func<Location, Task> action)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<List<Location>> GetAllModifiedSince(DateTime dateTime)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Retrieves a single entity by its entity number
+        /// </summary>
+        /// <param name="baccountId">baccount ID for whih to fetch locations.</param>
+        /// <param name="locationId">location ID for the location to fetch.</param>
+        /// <returns>T</returns>
         public async Task<Location> Get(string baccountId, string locationId)
         {
             return await VismaNetApiHelper.Get<Location>($"{baccountId}/{locationId}", VismaNetControllers.Locations, Authorization);
         }
 
+        /// <summary>
+        ///     Retrieves all entities from Visma.Net. WARNING: Slow.
+        /// </summary>
+        /// <returns>List of all entities</returns>
         public async Task<List<Location>> All(string baccountId)
         {
             return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
         }
+
+        /// <summary>
+        ///     Retrieves all entities from Visma.Net. WARNING: Slow.
+        /// </summary>
+        /// <returns>List of all entities</returns>
+        public async Task<List<Location>> Find(string baccountId, NameValueCollection parameters)
+        {
+            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization, parameters);
+        }
+
+        /// <summary>
+        ///     Executes the action on all elements streamed from the API.
+        /// </summary>
+        /// <param name="baccountId">baccount ID for whih to fetch locations.</param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public async Task ForEach(string baccountId, Action<Location> action)
+        {
+            await VismaNetApiHelper.ForEach($"{VismaNetControllers.Locations}/{baccountId}", Authorization, (Location obj) =>
+            {
+                action(obj);
+                return Task.FromResult(true);
+            });
+        }
+
+        /// <summary>
+        ///     Executes the action on all elements streamed from the API.
+        /// </summary>
+        /// <param name="baccountId">baccount ID for whih to fetch locations.</param>
+        /// <param name="action">This action can be async.</param>
+        /// <returns></returns>
+        public async Task ForEach(string baccountId, Func<Location, Task> action)
+        {
+            await VismaNetApiHelper.ForEach($"{VismaNetControllers.Locations}/{baccountId}", Authorization, action);
+        }
+
+        /// <summary>
+        ///     Retrieves all entities modified since given datetime from Visma.Net.
+        /// </summary>
+        /// <returns>List of all entities</returns>
+        public async Task<List<Location>> GetAllModifiedSince(string baccountId, DateTime dateTime)
+        {
+            if (dateTime == DateTime.MinValue)
+            {
+                var rsp = await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
+                rsp.ForEach(x => x.PrepareForUpdate());
+                return rsp;
+            }
+            else
+            {
+                var rsp = await VismaNetApiHelper.GetAllModifiedSince<Location>($"{VismaNetControllers.Locations}/{baccountId}", dateTime, Authorization);
+                rsp.ForEach(x => x.PrepareForUpdate());
+                return rsp;
+            }
+
+        }
+
     }
 }

--- a/Visma.net/lib/DAta/LocationData.cs
+++ b/Visma.net/lib/DAta/LocationData.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ONIT.VismaNetApi.Models;
+
+namespace ONIT.VismaNetApi.Lib.Data
+{
+    public class LocationData : BaseCrudDataClass<Location>
+    {
+        internal LocationData(VismaNetAuthorization auth) : base(auth)
+        {
+            ApiControllerUri = VismaNetControllers.Locations;
+        }
+
+        public override Task<Location> Get(string entityNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<List<Location>> All()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<Location> Get(string baccountId, string locationId)
+        {
+            return await VismaNetApiHelper.Get<Location>($"{baccountId}/{locationId}", VismaNetControllers.Locations, Authorization);
+        }
+
+        public async Task<List<Location>> All(string baccountId)
+        {
+            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
+        }
+    }
+}

--- a/Visma.net/lib/DAta/LocationData.cs
+++ b/Visma.net/lib/DAta/LocationData.cs
@@ -6,41 +6,32 @@ using ONIT.VismaNetApi.Models;
 
 namespace ONIT.VismaNetApi.Lib.Data
 {
-    public class LocationData : BaseCrudDataClass<Location>
+    public class LocationData : BaseDataClass 
     {
         internal LocationData(VismaNetAuthorization auth) : base(auth)
         {
             ApiControllerUri = VismaNetControllers.Location;
         }
 
-        public override Task<Location> Get(string entityNumber)
+        /// <summary>
+        ///     Creates a new entity
+        /// </summary>
+        /// <param name="entity">Entity to create</param>
+        /// <returns>The created entity from Visma.Net</returns>
+        public virtual async Task<Location> Add(Location entity)
         {
-            throw new NotImplementedException();
+            var rsp = await VismaNetApiHelper.Create(entity, ApiControllerUri, Authorization);
+            rsp.InternalPrepareForUpdate();
+            return rsp;
         }
 
-        public override Task<List<Location>> All()
+        /// <summary>
+        ///     Updates an entity
+        /// </summary>
+        /// <param name="entity">Entity to update</param>
+        public virtual async Task Update(Location entity)
         {
-            throw new NotImplementedException();
-        }
-
-        public override Task<List<Location>> Find(NameValueCollection parameters)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override Task ForEach(Action<Location> action)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override Task ForEach(Func<Location, Task> action)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override Task<List<Location>> GetAllModifiedSince(DateTime dateTime)
-        {
-            throw new NotImplementedException();
+            await VismaNetApiHelper.Update(entity, entity.GetIdentificator(), ApiControllerUri, Authorization);
         }
 
         /// <summary>

--- a/Visma.net/lib/DAta/LocationData.cs
+++ b/Visma.net/lib/DAta/LocationData.cs
@@ -10,7 +10,7 @@ namespace ONIT.VismaNetApi.Lib.Data
     {
         internal LocationData(VismaNetAuthorization auth) : base(auth)
         {
-            ApiControllerUri = VismaNetControllers.Locations;
+            ApiControllerUri = VismaNetControllers.Location;
         }
 
         public override Task<Location> Get(string entityNumber)
@@ -51,7 +51,7 @@ namespace ONIT.VismaNetApi.Lib.Data
         /// <returns>T</returns>
         public async Task<Location> Get(string baccountId, string locationId)
         {
-            return await VismaNetApiHelper.Get<Location>($"{baccountId}/{locationId}", VismaNetControllers.Locations, Authorization);
+            return await VismaNetApiHelper.Get<Location>($"{baccountId}/{locationId}", VismaNetControllers.Location, Authorization);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace ONIT.VismaNetApi.Lib.Data
         /// <returns>List of all entities</returns>
         public async Task<List<Location>> All(string baccountId)
         {
-            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
+            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Location}/{baccountId}", Authorization);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace ONIT.VismaNetApi.Lib.Data
         /// <returns>List of all entities</returns>
         public async Task<List<Location>> Find(string baccountId, NameValueCollection parameters)
         {
-            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization, parameters);
+            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Location}/{baccountId}", Authorization, parameters);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace ONIT.VismaNetApi.Lib.Data
         /// <returns></returns>
         public async Task ForEach(string baccountId, Action<Location> action)
         {
-            await VismaNetApiHelper.ForEach($"{VismaNetControllers.Locations}/{baccountId}", Authorization, (Location obj) =>
+            await VismaNetApiHelper.ForEach($"{VismaNetControllers.Location}/{baccountId}", Authorization, (Location obj) =>
             {
                 action(obj);
                 return Task.FromResult(true);
@@ -95,7 +95,7 @@ namespace ONIT.VismaNetApi.Lib.Data
         /// <returns></returns>
         public async Task ForEach(string baccountId, Func<Location, Task> action)
         {
-            await VismaNetApiHelper.ForEach($"{VismaNetControllers.Locations}/{baccountId}", Authorization, action);
+            await VismaNetApiHelper.ForEach($"{VismaNetControllers.Location}/{baccountId}", Authorization, action);
         }
 
         /// <summary>
@@ -106,13 +106,13 @@ namespace ONIT.VismaNetApi.Lib.Data
         {
             if (dateTime == DateTime.MinValue)
             {
-                var rsp = await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
+                var rsp = await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Location}/{baccountId}", Authorization);
                 rsp.ForEach(x => x.PrepareForUpdate());
                 return rsp;
             }
             else
             {
-                var rsp = await VismaNetApiHelper.GetAllModifiedSince<Location>($"{VismaNetControllers.Locations}/{baccountId}", dateTime, Authorization);
+                var rsp = await VismaNetApiHelper.GetAllModifiedSince<Location>($"{VismaNetControllers.Location}/{baccountId}", dateTime, Authorization);
                 rsp.ForEach(x => x.PrepareForUpdate());
                 return rsp;
             }

--- a/Visma.net/lib/DAta/SalesOrderData.cs
+++ b/Visma.net/lib/DAta/SalesOrderData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using ONIT.VismaNetApi.Models;
+﻿using ONIT.VismaNetApi.Models;
 using System.Threading.Tasks;
 
 namespace ONIT.VismaNetApi.Lib.Data
@@ -37,39 +35,6 @@ namespace ONIT.VismaNetApi.Lib.Data
             }
             rsp.InternalPrepareForUpdate();
             return rsp;
-        }
-    }
-
-    public class LocationData : BaseCrudDataClass<Location>
-    {
-        internal LocationData(VismaNetAuthorization auth) : base(auth)
-        {
-            ApiControllerUri = VismaNetControllers.Locations;
-        }
-
-        protected LocationData() : base(null)
-        {
-            ApiControllerUri = VismaNetControllers.Locations;
-        }
-
-        public override Task<Location> Get(string entityNumber)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override Task<List<Location>> All()
-        {
-            throw new NotImplementedException();
-        }
-
-        public async Task<Location> Get(string baccountId, string locationId)
-        {
-            return await VismaNetApiHelper.Get<Location>($"{baccountId}/{locationId}", VismaNetControllers.Locations, Authorization);
-        }
-
-        public async Task<List<Location>> All(string baccountId)
-        {
-            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
         }
     }
 }

--- a/Visma.net/lib/DAta/SalesOrderData.cs
+++ b/Visma.net/lib/DAta/SalesOrderData.cs
@@ -1,4 +1,6 @@
-﻿using ONIT.VismaNetApi.Models;
+﻿using System;
+using System.Collections.Generic;
+using ONIT.VismaNetApi.Models;
 using System.Threading.Tasks;
 
 namespace ONIT.VismaNetApi.Lib.Data
@@ -35,6 +37,39 @@ namespace ONIT.VismaNetApi.Lib.Data
             }
             rsp.InternalPrepareForUpdate();
             return rsp;
+        }
+    }
+
+    public class LocationData : BaseCrudDataClass<Location>
+    {
+        internal LocationData(VismaNetAuthorization auth) : base(auth)
+        {
+            ApiControllerUri = VismaNetControllers.Locations;
+        }
+
+        protected LocationData() : base(null)
+        {
+            ApiControllerUri = VismaNetControllers.Locations;
+        }
+
+        public override Task<Location> Get(string entityNumber)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<List<Location>> All()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<Location> Get(string baccountId, string locationId)
+        {
+            return await VismaNetApiHelper.Get<Location>($"{baccountId}/{locationId}", VismaNetControllers.Locations, Authorization);
+        }
+
+        public async Task<List<Location>> All(string baccountId)
+        {
+            return await VismaNetApiHelper.GetAll<Location>($"{VismaNetControllers.Locations}/{baccountId}", Authorization);
         }
     }
 }

--- a/Visma.net/lib/VismaNetApiHelper.cs
+++ b/Visma.net/lib/VismaNetApiHelper.cs
@@ -321,16 +321,6 @@ namespace ONIT.VismaNetApi.Lib
             }
         }
 
-        internal static IEnumerable<T> GetAllEnumerable<T>(string apiControllerUri, VismaNetAuthorization authorization)
-
-        {
-            using (var webclient = GetHttpClient(authorization))
-            {
-                foreach (var entity in webclient.GetEnumerable<T>(GetApiUrlForController(apiControllerUri)))
-                    yield return entity;
-            }
-        }
-
         public static async Task ForEach<T>(string apiControllerUri, VismaNetAuthorization authorization,
             Func<T, Task> action, NameValueCollection parameters = null) where T : DtoProviderBase
         {

--- a/Visma.net/lib/VismaNetControllers.cs
+++ b/Visma.net/lib/VismaNetControllers.cs
@@ -27,7 +27,7 @@ namespace ONIT.VismaNetApi.Lib
         public const string Branch = "controller/api/v1/branch";
 		public const string Attachment = "controller/api/v1/attachment";
         public const string Warehouse = "controller/api/v1/warehouse";
-        public const string Locations = "controller/api/v1/location";
+        public const string Location = "controller/api/v1/location";
 
         public const string OAuthAuthorize = "resources/oauth/authorize";
     }

--- a/Visma.net/lib/VismaNetControllers.cs
+++ b/Visma.net/lib/VismaNetControllers.cs
@@ -27,6 +27,7 @@ namespace ONIT.VismaNetApi.Lib
         public const string Branch = "controller/api/v1/branch";
 		public const string Attachment = "controller/api/v1/attachment";
         public const string Warehouse = "controller/api/v1/warehouse";
+        public const string Locations = "controller/api/v1/location";
 
         public const string OAuthAuthorize = "resources/oauth/authorize";
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 -
-  version: 3.0.0-pre-{build}
+  version: 3.0.1-pre-{build}
   image: Visual Studio 2017  
   pull_requests:
     do_not_increment_build_number: true


### PR DESCRIPTION
Visma.net version 6.13 saw the release of /location, enabling developers to get/create/update customer locations.

The implementation differs slightly compared to other endpoints as /location in almost all circumstances requires a baccountId. 

eg. 
GET /location/{baccountid}
returns a range of locations for a BAccount. 

GET /location/{baccountid}/{locationid}
Returns a specific location of a BAccount. 