### PR TITLE
Dynamic GetStream and GetAllModifiedSince

### DIFF
--- a/Visma.net/Dynamic/VismaNetDynamicEndpoint.cs
+++ b/Visma.net/Dynamic/VismaNetDynamicEndpoint.cs
@@ -40,6 +40,11 @@ namespace ONIT.VismaNetApi.Dynamic
             }
         }
 
+        public async Task<dynamic> GetAllModifiedSince(DateTime date)
+        {
+            return await VismaNetApiHelper.GetAllModifiedSince<JObject>($"{_base}{_endpointName}", date, _auth);
+        }
+
         public async Task<Stream> GetStream()
         {
             return await VismaNetApiHelper.GetStream($"{_base}{_endpointName}", _auth);

--- a/Visma.net/Dynamic/VismaNetDynamicEndpoint.cs
+++ b/Visma.net/Dynamic/VismaNetDynamicEndpoint.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Dynamic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -39,6 +40,10 @@ namespace ONIT.VismaNetApi.Dynamic
             }
         }
 
+        public async Task<Stream> GetStream()
+        {
+            return await VismaNetApiHelper.GetStream($"{_base}{_endpointName}", _auth);
+        }
 
         #endregion
         public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)

--- a/Visma.net/lib/VismaNetApiHelper.cs
+++ b/Visma.net/lib/VismaNetApiHelper.cs
@@ -388,6 +388,16 @@ namespace ONIT.VismaNetApi.Lib
             }
         }
 
+        internal static async Task<Stream> GetStream(string apiControllerUri, VismaNetAuthorization authorization)
+        {
+            var client = GetHttpClient(authorization);
+            {
+                var endpoint = GetApiUrlForController(apiControllerUri);
+
+                return await client.GetStream(endpoint);
+            }
+        }
+
         internal static async Task<Stream> GetAttachment(VismaNetAuthorization auth, string attachmentid)
         {
             var client = GetHttpClient(auth);


### PR DESCRIPTION
Added convenience methods for getting the stream of a dynamic endpoint as mentioned in #119 and also GetAllModifiedSince.