### PR TITLE
Customer CreditTerms

### DIFF
--- a/Visma.net/Models/Customer.cs
+++ b/Visma.net/Models/Customer.cs
@@ -66,7 +66,7 @@ namespace ONIT.VismaNetApi.Models
         public CreditTerms creditTerms
         {
             get => Get("creditTermsId", new CreditTerms());
-            set => Set(value);
+            set => Set(value, "creditTermsId");
         }
 
 


### PR DESCRIPTION
Fix the creditTerms by setting the Set method explicitly to creditTermsId. This way the serialized value will be recognized by Visma.NET 

#152 