### PR TITLE
Supplier creditTerms

### DIFF
--- a/Visma.net/Models/Supplier.cs
+++ b/Visma.net/Models/Supplier.cs
@@ -68,8 +68,8 @@ namespace ONIT.VismaNetApi.Models
 
         public CreditTerms creditTerms
         {
-            get => Get("creditTermsId", new CreditTerms("30"));
-            set => Set(value);
+            get => Get("creditTermsId", new CreditTerms());
+            set => Set(value, "creditTermsId");
         }
 
         public string currencyId
@@ -88,7 +88,8 @@ namespace ONIT.VismaNetApi.Models
 
         [JsonProperty] public JObject extras { get; private set; }
 
-        public SupplierGLAccountDto glAccounts {
+        public SupplierGLAccountDto glAccounts
+        {
             get => Get<SupplierGLAccountDto>();
             set => Set(value);
         }


### PR DESCRIPTION
Fix the creditTerms by setting the Set method explicitly to creditTermsId. This way the serialized value will be recognized by Visma.NET. Remove the 30 parameter from the get constructor.